### PR TITLE
refactor the average analysis page

### DIFF
--- a/app/src/main/java/com/example/dailydose/AvgBarGraph.java
+++ b/app/src/main/java/com/example/dailydose/AvgBarGraph.java
@@ -49,15 +49,10 @@ public class AvgBarGraph extends AppCompatActivity {
 
         //Get the anyChartView and Progress bar from the xml file
         AnyChartView anyChartView = findViewById(R.id.any_chart_avg);
+        APIlib.getInstance().setActiveAnyChartView(anyChartView);
         anyChartView.setProgressBar(findViewById(R.id.progress_bar));
-        AnyChartView anyChartView_top = findViewById(R.id.any_chart_avg_top);
-        anyChartView_top.setProgressBar(findViewById(R.id.progress_bar_top));
-        AnyChartView anyChartView_low = findViewById(R.id.any_chart_avg_low);
-        anyChartView_low.setProgressBar(findViewById(R.id.progress_bar_low));
 
         Cartesian cartesian = AnyChart.column();
-        Cartesian cartesian_top = AnyChart.column();
-        Cartesian cartesian_low = AnyChart.column();
 
         // get the Entries currently in the database
         List<Entry> result = JsonUtils.getEntries("TestFile.json", getApplicationContext());
@@ -83,8 +78,8 @@ public class AvgBarGraph extends AppCompatActivity {
         {
             @Override
             public int compare(Map.Entry<String, Double> o1, Map.Entry<String, Double> o2) {
-                int valueComparison = o1.getValue().compareTo(o2.getValue());
-                return valueComparison == 0 ? o1.getKey().compareTo(o2.getKey()) : valueComparison;
+                int valueComparison = o2.getValue().compareTo(o1.getValue());
+                return valueComparison == 0 ? o2.getKey().compareTo(o1.getKey()) : valueComparison;
             }
         });
 
@@ -92,11 +87,10 @@ public class AvgBarGraph extends AppCompatActivity {
         {
             @Override
             public int compare(Map.Entry<String, Double> o1, Map.Entry<String, Double> o2) {
-                int valueComparison = o2.getValue().compareTo(o1.getValue());
-                return valueComparison == 0 ? o2.getKey().compareTo(o1.getKey()) : valueComparison;
+                int valueComparison = o1.getValue().compareTo(o2.getValue());
+                return valueComparison == 0 ? o1.getKey().compareTo(o2.getKey()) : valueComparison;
             }
         });
-
 
         // sort the entries by value
         for(Map.Entry<String,Double> e: avgRating.entrySet()) {
@@ -142,8 +136,13 @@ public class AvgBarGraph extends AppCompatActivity {
 
         anyChartView.setChart(cartesian);
 
+        AnyChartView anyChartView_top = findViewById(R.id.any_chart_avg_top);
+        APIlib.getInstance().setActiveAnyChartView(anyChartView_top);
+        anyChartView_top.setProgressBar(findViewById(R.id.progress_bar_top));
+        Cartesian cartesian_top = AnyChart.column();
+
         // Set up the average ratings for top rating tags
-        Column column_top = cartesian.column(data_top);
+        Column column_top = cartesian_top.column(data_top);
 
         column_top.tooltip()
                 .titleFormat("{%X}")
@@ -168,8 +167,13 @@ public class AvgBarGraph extends AppCompatActivity {
 
         anyChartView_top.setChart(cartesian_top);
 
+        AnyChartView anyChartView_low = findViewById(R.id.any_chart_avg_low);
+        APIlib.getInstance().setActiveAnyChartView(anyChartView_low);
+        anyChartView_low.setProgressBar(findViewById(R.id.progress_bar_low));
+        Cartesian cartesian_low = AnyChart.column();
+
         // Set up the average ratings for low rating tags
-        Column column_low = cartesian.column(data_low);
+        Column column_low = cartesian_low.column(data_low);
 
         column_low.tooltip()
                 .titleFormat("{%X}")

--- a/app/src/main/java/com/example/dailydose/AvgBarGraph.java
+++ b/app/src/main/java/com/example/dailydose/AvgBarGraph.java
@@ -3,12 +3,14 @@ package com.example.dailydose;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
+import com.anychart.APIlib;
 import com.anychart.AnyChart;
 import com.anychart.AnyChartView;
 import com.anychart.chart.common.dataentry.DataEntry;
@@ -21,10 +23,15 @@ import com.anychart.enums.Position;
 import com.anychart.enums.TooltipPositionMode;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.Dictionary;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 
 public class AvgBarGraph extends AppCompatActivity {
@@ -43,8 +50,14 @@ public class AvgBarGraph extends AppCompatActivity {
         //Get the anyChartView and Progress bar from the xml file
         AnyChartView anyChartView = findViewById(R.id.any_chart_avg);
         anyChartView.setProgressBar(findViewById(R.id.progress_bar));
+        AnyChartView anyChartView_top = findViewById(R.id.any_chart_avg_top);
+        anyChartView_top.setProgressBar(findViewById(R.id.progress_bar_top));
+        AnyChartView anyChartView_low = findViewById(R.id.any_chart_avg_low);
+        anyChartView_low.setProgressBar(findViewById(R.id.progress_bar_low));
 
         Cartesian cartesian = AnyChart.column();
+        Cartesian cartesian_top = AnyChart.column();
+        Cartesian cartesian_low = AnyChart.column();
 
         // get the Entries currently in the database
         List<Entry> result = JsonUtils.getEntries("TestFile.json", getApplicationContext());
@@ -60,12 +73,50 @@ public class AvgBarGraph extends AppCompatActivity {
         // Convert the tags and their average ratings to DataEntry objects and put them in
         // a list to be used to create the graph
         List<DataEntry> data = new ArrayList<>();
+        List<DataEntry> data_top = new ArrayList<>();
+        List<DataEntry> data_low = new ArrayList<>();
         for(Map.Entry<String,Double> e: avgRating.entrySet()) {
             data.add(new ValueDataEntry(e.getKey(), e.getValue()));
         }
 
+        TreeSet<Map.Entry<String, Double>> avgRatingTop = new TreeSet<>(new Comparator<Map.Entry<String, Double>>()
+        {
+            @Override
+            public int compare(Map.Entry<String, Double> o1, Map.Entry<String, Double> o2) {
+                int valueComparison = o1.getValue().compareTo(o2.getValue());
+                return valueComparison == 0 ? o1.getKey().compareTo(o2.getKey()) : valueComparison;
+            }
+        });
 
-        // Set up the Graph
+        TreeSet<Map.Entry<String, Double>> avgRatingLow = new TreeSet<>(new Comparator<Map.Entry<String, Double>>()
+        {
+            @Override
+            public int compare(Map.Entry<String, Double> o1, Map.Entry<String, Double> o2) {
+                int valueComparison = o2.getValue().compareTo(o1.getValue());
+                return valueComparison == 0 ? o2.getKey().compareTo(o1.getKey()) : valueComparison;
+            }
+        });
+
+
+        // sort the entries by value
+        for(Map.Entry<String,Double> e: avgRating.entrySet()) {
+            avgRatingTop.add(e);
+            avgRatingLow.add(e);
+        }
+        int i = 0;
+        Iterator<Map.Entry<String, Double>> itr_top = avgRatingTop.iterator();
+        Iterator<Map.Entry<String, Double>> itr_low = avgRatingLow.iterator();
+        // number of tags to display
+        while(itr_top.hasNext() && i < 3){
+            Map.Entry<String, Double> nextTop = itr_top.next();
+            data_top.add(new ValueDataEntry(nextTop.getKey(),nextTop.getValue()));
+            Map.Entry<String, Double> nextLow = itr_low.next();
+            data_low.add(new ValueDataEntry(nextLow.getKey(),nextLow.getValue()));
+            i ++;
+        }
+
+
+        // Set up the average ratings for all tags
         Column column = cartesian.column(data);
 
         column.tooltip()
@@ -90,6 +141,58 @@ public class AvgBarGraph extends AppCompatActivity {
         cartesian.yAxis(0).title("Rating");
 
         anyChartView.setChart(cartesian);
+
+        // Set up the average ratings for top rating tags
+        Column column_top = cartesian.column(data_top);
+
+        column_top.tooltip()
+                .titleFormat("{%X}")
+                .position(Position.CENTER_BOTTOM)
+                .anchor(Anchor.CENTER_BOTTOM)
+                .offsetX(0d)
+                .offsetY(5d)
+                .format("{%Value}{groupsSeparator: }");
+
+        cartesian_top.animation(true);
+        cartesian_top.title("Top rating tags");
+
+        cartesian_top.yScale().minimum(0d);
+
+        cartesian_top.yAxis(0).labels().format("{%Value}{groupsSeparator: }");
+
+        cartesian_top.tooltip().positionMode(TooltipPositionMode.POINT);
+        cartesian_top.interactivity().hoverMode(HoverMode.BY_X);
+
+        cartesian_top.xAxis(0).title("Tag");
+        cartesian_top.yAxis(0).title("Rating");
+
+        anyChartView_top.setChart(cartesian_top);
+
+        // Set up the average ratings for low rating tags
+        Column column_low = cartesian.column(data_low);
+
+        column_low.tooltip()
+                .titleFormat("{%X}")
+                .position(Position.CENTER_BOTTOM)
+                .anchor(Anchor.CENTER_BOTTOM)
+                .offsetX(0d)
+                .offsetY(5d)
+                .format("{%Value}{groupsSeparator: }");
+
+        cartesian_low.animation(true);
+        cartesian_low.title("Lowest rating tags");
+
+        cartesian_low.yScale().minimum(0d);
+
+        cartesian_low.yAxis(0).labels().format("{%Value}{groupsSeparator: }");
+
+        cartesian_low.tooltip().positionMode(TooltipPositionMode.POINT);
+        cartesian_low.interactivity().hoverMode(HoverMode.BY_X);
+
+        cartesian_low.xAxis(0).title("Tag");
+        cartesian_low.yAxis(0).title("Rating");
+
+        anyChartView_low.setChart(cartesian_low);
     }
 
     // Inflates options menu from menu_main xml file

--- a/app/src/main/java/com/example/dailydose/TagAnalysisView.java
+++ b/app/src/main/java/com/example/dailydose/TagAnalysisView.java
@@ -310,7 +310,7 @@ public class TagAnalysisView extends AppCompatActivity{
         } else if (id == R.id.action_avg){
             // change to the rating analysis screen
             Context context = TagAnalysisView.this;
-            Class destinationActivity = TagAnalysisView.class;
+            Class destinationActivity = AvgBarGraph.class;
             Intent mainIntent = new Intent(context, destinationActivity);
             startActivity(mainIntent);
             return true;

--- a/app/src/main/res/layout/avg_rating_analysis.xml
+++ b/app/src/main/res/layout/avg_rating_analysis.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="#FCF8DF"
+    android:visibility="visible"
     tools:context=".AvgBarGraph">
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -55,19 +56,21 @@
 
                 <com.anychart.AnyChartView
                     android:id="@+id/any_chart_avg"
-                    android:layout_width="wrap_content"
+                    android:layout_width="400dp"
                     android:layout_height="match_parent"
                     android:layout_marginTop="80dp"
-                    android:layout_marginBottom="78dp" />
+                    android:layout_marginBottom="78dp"
+                    android:visibility="visible">
 
-                <ProgressBar
-                    android:id="@+id/progress_bar"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content" />
+                    <ProgressBar
+                        android:id="@+id/progress_bar"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content" />
+                </com.anychart.AnyChartView>
 
                 <com.anychart.AnyChartView
                     android:id="@+id/any_chart_avg_top"
-                    android:layout_width="match_parent"
+                    android:layout_width="400dp"
                     android:layout_height="match_parent"
                     android:layout_marginTop="80dp"
                     android:layout_marginBottom="78dp" />
@@ -79,7 +82,7 @@
 
                 <com.anychart.AnyChartView
                     android:id="@+id/any_chart_avg_low"
-                    android:layout_width="match_parent"
+                    android:layout_width="400dp"
                     android:layout_height="match_parent"
                     android:layout_marginTop="80dp"
                     android:layout_marginBottom="78dp" />
@@ -92,7 +95,6 @@
             </LinearLayout>
 
         </HorizontalScrollView>
-
 
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/avg_rating_analysis.xml
+++ b/app/src/main/res/layout/avg_rating_analysis.xml
@@ -40,28 +40,60 @@
             app:layout_constraintTop_toTopOf="@+id/header_avg"
             app:layout_constraintVertical_bias="0.0" />
 
-        <com.anychart.AnyChartView
-            android:id="@+id/any_chart_avg"
+        <HorizontalScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginTop="80dp"
-            android:layout_marginBottom="78dp"
-            app:layout_constraintBottom_toTopOf="parent"
-            app:layout_constraintEnd_toEndOf="@+id/header"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="@+id/header"
-            app:layout_constraintTop_toTopOf="@+id/header"
-            app:layout_constraintVertical_bias="0.0" />
-
-        <ProgressBar
-            android:id="@+id/progress_bar"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_marginTop="78dp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            />
+            app:layout_constraintTop_toBottomOf="@+id/header_avg">
+
+            <LinearLayout
+                android:id="@+id/barGraphGallery"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:orientation="horizontal">
+
+                <com.anychart.AnyChartView
+                    android:id="@+id/any_chart_avg"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:layout_marginTop="80dp"
+                    android:layout_marginBottom="78dp" />
+
+                <ProgressBar
+                    android:id="@+id/progress_bar"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content" />
+
+                <com.anychart.AnyChartView
+                    android:id="@+id/any_chart_avg_top"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_marginTop="80dp"
+                    android:layout_marginBottom="78dp" />
+
+                <ProgressBar
+                    android:id="@+id/progress_bar_top"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content" />
+
+                <com.anychart.AnyChartView
+                    android:id="@+id/any_chart_avg_low"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_marginTop="80dp"
+                    android:layout_marginBottom="78dp" />
+
+                <ProgressBar
+                    android:id="@+id/progress_bar_low"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content" />
+
+            </LinearLayout>
+
+        </HorizontalScrollView>
+
+
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/avg_rating_analysis.xml
+++ b/app/src/main/res/layout/avg_rating_analysis.xml
@@ -65,7 +65,9 @@
                     <ProgressBar
                         android:id="@+id/progress_bar"
                         android:layout_width="wrap_content"
-                        android:layout_height="wrap_content" />
+                        android:layout_height="wrap_content"
+                        android:paddingHorizontal="180dp"
+                        android:paddingVertical="200dp" />
                 </com.anychart.AnyChartView>
 
                 <com.anychart.AnyChartView
@@ -73,24 +75,30 @@
                     android:layout_width="400dp"
                     android:layout_height="match_parent"
                     android:layout_marginTop="80dp"
-                    android:layout_marginBottom="78dp" />
+                    android:layout_marginBottom="78dp" >
 
-                <ProgressBar
-                    android:id="@+id/progress_bar_top"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content" />
+                    <ProgressBar
+                        android:id="@+id/progress_bar_top"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:paddingHorizontal="180dp"
+                        android:paddingVertical="200dp" />
+                </com.anychart.AnyChartView>
 
                 <com.anychart.AnyChartView
                     android:id="@+id/any_chart_avg_low"
                     android:layout_width="400dp"
                     android:layout_height="match_parent"
                     android:layout_marginTop="80dp"
-                    android:layout_marginBottom="78dp" />
+                    android:layout_marginBottom="78dp" >
 
-                <ProgressBar
-                    android:id="@+id/progress_bar_low"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content" />
+                    <ProgressBar
+                        android:id="@+id/progress_bar_low"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:paddingHorizontal="180dp"
+                        android:paddingVertical="200dp" />
+                </com.anychart.AnyChartView>
 
             </LinearLayout>
 


### PR DESCRIPTION
Since the graph will not display the names for each tag when we have more and more tags, I refactor the average analysis page to contain a horizontally scrollable view containing three bar graphs: one for all tags, one for top rating tags (currently displaying 3, subject to change) and one for lowest rating tags.